### PR TITLE
[libphobos] Add newly built libgcc to library paths when testing

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,23 @@
+version: v1.0
+name: GDC Semaphore 2.0 test pipeline
+agent:
+  machine:
+    type: e1-standard-8
+    os_image: ubuntu1804
+
+blocks:
+  - name: "GDC"
+    task:
+      jobs:
+      - name: "Testsuite"
+        commands:
+          - checkout --use-cache
+          - ./buildci.sh setup
+          - ./buildci.sh build
+          - ./buildci.sh testsuite
+      - name: "Unit Tests"
+        commands:
+          - checkout --use-cache
+          - ./buildci.sh setup
+          - ./buildci.sh build
+          - ./buildci.sh unittests

--- a/README.md
+++ b/README.md
@@ -1,0 +1,247 @@
+## The GDC D Compiler [![Build Status](https://semaphoreci.com/api/v1/jpf91/gcc-2/branches/trunk/badge.svg)](https://semaphoreci.com/jpf91/gcc-2) [![Build status](https://badge.buildkite.com/58fd9d7cf59f6c774888051edb0e037fad6d97bcf04e53ac4f.svg?branch=trunk)](https://buildkite.com/d-programming-gdc/gcc)
+
+GDC is the GCC-based [D language][dlang] compiler, integrating the open source [DMDFE D][dmd] front end
+with [GCC][gcc] as the backend. The GNU D Compiler (GDC) project was originally started by David Friedman
+in 2004 until early 2007 when he disappeared from the D scene, and was no longer able to maintain GDC.
+Following a revival attempt in 2008, GDC is now under the lead of Iain Buclaw who has been steering the
+project since 2009 with the assistance of its contributors, without them the project would not have been
+nearly as successful as it has been.
+
+Documentation on GDC is available from [the wiki][wiki]. Any bugs or issues found with using GDC should
+be reported at [the GCC bugzilla site][bugs] with the bug component set to `d`. For help with GDC, the
+[D.gnu][maillist] mailing list is the place to go with questions or problems. There's also a GDC IRC
+channel at #d.gdc on FreeNode. Any questions which are related to the D language, but not directly to
+the GDC compiler, can be asked in the [D forums][dforum]. You can find more information about D, including
+example code, API documentation, tutorials and these forums at the [main D website][dlang].
+
+### Building GDC
+
+Stable GDC releases for production usage should be obtained by downloading stable GCC sources
+from the [GCC downloads][gcc-download] site.
+For the latest experimental development version, simply download a [GCC snapshot][gcc-snapshot] or
+checkout the GCC SVN or git mirror repository. Most GDC development directly targets the GCC SVN repository,
+so the latest GDC version is always available in the GCC SVN.
+Do not use the `trunk` branch in this repository, as it is rebased regularly and contains exclusively
+CI related changes.
+
+During certain development phases (e.g. when GCC is in a feature freeze) larger GDC changes may be staged
+to the `gdc-next` branch. This branch is rebased irregularly, do not rely on the commit ids to be
+stable.
+
+If you need to clone this repo for some reason, you may want to do a shallow clone using the
+`--depth 1 --no-single-branch` git options, as this repository is large. To compile GDC, add `--enable-languages=d` to the GCC configure flags and [start building][gdc-build]. 
+
+### Using GDC
+
+Usage information can be found at ...
+
+### Contributing to GDC
+
+Starting with GCC 9.0.0, GDC has been merged into upstream GCC and all GDC development now follows the usual
+GCC development process. Changes to GDC and related code can therefore be submitted
+to the [gcc-patches mailing list][patches-ml] for review.
+
+It is possible to directly post patches to the [mailing list][patches-ml] and not to use this repository at all.
+We however recommend using this repository to make use of the CI checks and the github review workflow.
+
+#### Submitting Changes
+
+To submit changes to GDC, simply fork this repository, create a new feature branch based on the `trunk` branch
+and open a pull request for that branch. We recommend using full clones for development, allthough using shallow
+clones should also be possible. In code:
+
+```bash
+# Initial one time setup:
+# For repository on github, then clone your fork
+git clone git@github.com:[you]/gcc.git
+cd gcc
+# Add the gdc repository as a remote
+git remote add gdc git@github.com:D-Programming-GDC/gcc.git
+
+# Do this for every patch:
+# Fetch latest upstream changes
+git remote update
+# Base a new branch on gdc/trunk
+git checkout gdc/trunk
+git checkout -b pr12345
+# Make changes, commit
+git commit [...]
+git push origin pr12345:pr12345
+# Open a pull request on github
+```
+Opening a pull request will automatically trigger our CI and test your changes on various machines.
+
+#### Changelogs
+The GCC project requires keeping changes in the `Changelog` files. GCC ships a script which can generate
+Changelog templates for us if we feed it a diff:
+```bash
+git diff gdc/trunk | ./contrib/mklog
+```
+*Note:* The above command generates the diff between `gdc/trunk` and your local branch. If `gdc/trunk` was
+updated and you did a `git remote update`, `gdc/trunk` may have changes which are not yet in your branch.
+In that case, rebase onto `gdc/trunk` first.
+
+The command outputs something like this:
+```
+ChangeLog:
+
+2019-02-03  Johannes Pfau  <johannespfau@example.com>
+
+	* test.d: New file.
+
+gcc/d/ChangeLog:
+
+2019-02-03  Johannes Pfau  <johannespfau@example.com>
+
+	* dfile.txt: New file.
+
+libphobos/ChangeLog:
+
+2019-02-03  Johannes Pfau  <johannespfau@example.com>
+
+	* phobosfile.txt: New file.
+
+```
+
+The `ChangeLog:`, `libphobos/ChangeLog:` part gives the file into which the following changes need to be added.
+Complete the changelog text and use the existing entries in the files for reference or see
+the [GCC][changelog-doc] and [GNU][changelog-doc2] documentation. Also make sure to adhere to the line length limit of 80 characters. Then make the changelog somehow available for review:
+Either commit the files, or preferable, just copy and paste the edited text output of `mklog` into your
+pull request description.
+
+
+### Getting Changes Into GCC SVN
+
+After changes have been reviewed on github, they have to be pushed into the GCC SVN. Pull requests will
+not get merged into this repository. The following steps can be handled by GDC maintainers, although it is
+possible to perform these by yourself as well.
+
+##### Sumbitting to the gcc-patches Mailing List
+
+Once the review and CI have passed on the github pull request page, the changes need to be submitted to the
+`gcc-patches` mailing list. This can easily be done using [git send-email][git-send-email]:
+
+1. You might want to squash the commits. Each commit will become one email/patch so it might make sense
+   to combine commits here.
+2. The changelog should preferrably be pasted into the email text, so do not include
+   commits modifying the changelog files.
+3. If you had to regenerate any autogenerated files (e.g. configure from configure.ac)
+   you may keep these changes out of the patch for simplified review. The generated files
+   should still be present in the changelog.
+
+You'll have to configure `git send-email` once after you checked out the repository:
+```bash
+git config sendemail.to gcc-patches@gcc.gnu.org
+```
+If you never used `git send-email` before, you'll also have to setup the SMTP settings once.
+See [here][git-send-email] for details.
+
+Now to send the patches:
+```bash
+# Check which commits will be sent:
+git log gdc/trunk..
+# Check the complete diff which will be sent:
+git diff gdc/trunk..
+# Dry run to verify everything again
+git send-email gdc/trunk --annotate --dry-run
+# Send the patches
+git send-email gdc/trunk --annotate
+```
+
+If you send multiple patches and want to write an introduction email, use the `--compose` argument for
+`git send-email`. You can also generate patch files like this:
+```bash
+git format-patch gdc/trunk..
+# Edit the *.patch files, add messages etc.
+# Now send the patches
+git send-email *.patch --dry-run
+git send-email *.patch
+```
+
+##### Pushing Changes to SVN
+
+This section is only relevant for GDC maintainers with GCC SVN write access. There are certain rules when
+pushing to SVN, usually you're only allowed to push **after** the patches have been reviewed on the mailing list.
+Refer to the [GCC documentation][gcc-SVN] for details.
+
+```
+# We need the full repository for SVN integration
+git remote add gcc git://gcc.gnu.org/git/gcc.git
+git config --add remote.gcc.fetch 'refs/remotes/*:refs/remotes/SVN/*'
+git remote update
+git SVN init -s --prefix=SVN/ SVN+ssh://username@gcc.gnu.org/SVN/gcc
+# Update trunk branch to latest SVN commit
+git checkout -b trunk SVN/trunk
+git fetch
+git SVN rebase
+
+git checkout myfix
+# Rebase myfix branch to get rid of CI commits
+git rebase gdc/trunk --onto trunk
+# And merge
+git checkout trunk
+git merge --ff-only myfix
+# See commits we're going to commit
+git log -p @{u}..
+
+# And finally commit
+git SVN dcommit
+```
+
+### Repository Information
+
+This repository is a fork of the [GCC git mirror][gcc-git]. As the GCC main version control system is
+currently still using SVN, all GIT repositories are `git-SVN` bridges. This needs some special attention when
+performing some git operations.
+
+#### Directory Structure
+
+All code branches contain the complete GCC tree. D sources are in `gcc/d` for the compiler
+and in `libphobos` for the runtime library. Changes to files in `gcc/d/dmd` or `libphobos`
+should be submitted to the [upstream dlang repositories][dlang-github] first if possible.
+Refer to [gcc/d/README.gcc][gcc-d-readme] for more details.
+
+#### Branches
+
+Branches in this repository are organized in the following way:
+
+* CI branches: The `trunk` branch and release branches `gcc-*-branch` are based on the same
+  branches in the upstream GCC git repository. The only changes compared to the upstream branches
+  are CI-related setup commits. CI branches are updated automatically to be kept in sync with
+  upstream and are rebased onto the upstream changes. These branches are effectively readonly:
+  We never merge into the branches in this repository. The CI related changes make it possible
+  to run CI based tests for any PR based on these branches, which is their sole purpose.
+* The `gdc-next` branch: If GCC is in a late [development stage][gcc-stage] this branch can accumulate
+  changes for the GCC release after the next one. It is essentially used to allow periodic merges from
+  [upstream DMD][dlang-github] when GCC development is frozen. Changes in the GCC `trunk` branch
+  are manually merged into this branch. When GCC enters stage 1 development again, this branch will be
+  rebased and pushed to upstream `trunk`. After that, the branch in this repository will be **rebased**
+  to trunk.
+* Backport branches: The `gcc-*-bp` branches contain D frontend and library feature updates for released GCC versions.
+  Regression fixes should target the main `gcc-*-branch` branches instead, according to GCC rules.
+
+
+
+[home]: https://gdcproject.org
+[dlang]: https://dlang.org
+[gcc]: https://gcc.gnu.org
+[dforum]: https://forum.dlang.org
+[dmd]: https://github.com/dlang/dmd
+[wiki]: https://wiki.dlang.org/GDC
+[bugs]: https://gcc.gnu.org/bugzilla
+[maillist]: https://forum.dlang.org/group/D.gnu
+[email]: mailto:ibuclaw@gdcproject.org
+[gcc-devel]: https://gcc.gnu.org/git/?p=gcc.git;a=shortlog
+[patches-ml]: https://gcc.gnu.org/lists.html
+[gcc-github]: https://github.com/gcc-mirror/gcc
+[gcc-git]: https://gcc.gnu.org/wiki/GitMirror
+[gcc-stage]: https://www.gnu.org/software/gcc/develop.html
+[dlang-github]: https://github.com/dlang
+[gdc-build]: https://wiki.dlang.org/GDC/Installation/Generic
+[changelog-doc]: https://www.gnu.org/software/gcc/codingconventions.html#ChangeLogs
+[changelog-doc2]: https://www.gnu.org/prep/standards/standards.html#Change-Logs
+[git-send-email]: https://www.freedesktop.org/wiki/Software/PulseAudio/HowToUseGitSendEmail/
+[gcc-download]: https://www.gnu.org/software/gcc/releases.html
+[gcc-SVN]: https://gcc.gnu.org/SVNwrite.html
+[gcc-d-readme]: https://github.com/jpf91/gcc/blob/trunk/gcc/d/README.gcc
+[gcc-snapshot]: https://www.gnu.org/software/gcc/snapshots.html

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,48 @@
+jobs:
+- job: Windows
+  timeoutInMinutes: 120
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    matrix:
+      x64:
+        OS: win64
+        MODEL: 64
+        ARCH: x64
+      x86:
+        OS: win32
+        MODEL: 32
+        ARCH: x86
+  steps:
+    - checkout: self
+      fetchDepth: 1
+    - script: |
+        git clone https://github.com/lazka/msys2-ci-base.git %CD:~0,2%\msys64
+        %CD:~0,2%\msys64\usr\bin\rm -rf %CD:~0,2%\msys64\.git
+      displayName: Install MSYS2
+    - script: |
+        set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
+      displayName: Update MSYS2
+
+- job: Linux_X86_ML
+  timeoutInMinutes: 120
+  pool:
+    vmImage: 'ubuntu-16.04'
+  variables:
+    AZURE: 'true'
+  steps:
+    - checkout: self
+      fetchDepth: 1
+    - script: |
+        ./buildci.sh setup
+      displayName: Install prerequisites
+    - script: |
+        ./buildci.sh build
+      displayName: Building GCC
+    - script: |
+        ./buildci.sh testsuite
+      displayName: Running testsuite
+    - script: |
+        ./buildci.sh unittests
+      displayName: Running unit tests

--- a/buildci.sh
+++ b/buildci.sh
@@ -1,0 +1,362 @@
+#!/bin/bash
+# This script is intended to be ran on SemaphoreCI or Buildkite platform.
+# Following environmental variables are assumed to be exported on SemaphoreCI.
+#
+# - SEMAPHORE_PROJECT_DIR
+# - SEMAPHORE_CACHE_DIR
+#
+# See https://semaphoreci.com/docs/available-environment-variables.html
+#
+# Following environmental variables are assumed to be exported on Buildkite.
+#
+# - BUILDKITE_CACHE_DIR
+# - BUILDKITE_TARGET
+# - BUILDKITE_BOOTSTRAP
+#
+# See https://buildkite.com/docs/builds/environment-variables
+#
+## Top-level build system configration.
+gcc_prereqs="gmp-6.1.0.tar.bz2 mpfr-3.1.4.tar.bz2 mpc-1.0.3.tar.gz isl-0.18.tar.bz2"
+host_package="7"
+
+export CC="gcc-${host_package}"
+export CXX="g++-${host_package}"
+export GDC="gdc-${host_package}"
+
+environment() {
+    ## Determine what flags to use for configure, build and testing the compiler.
+    ## Commonize CI environment variables.
+    #
+    # project_dir:              directory of checked out sources.
+    # cache_dir:                tarballs of downloaded dependencies cached
+    #                           between builds.
+    # build_host:               host triplet that build is ran from.
+    # build_host_canonical:     canonical version of host triplet.
+    # build_target:             target triplet of the compiler to build.
+    # build_target_canonical:   canonical version of target triplet.
+    # make_flags:               flags to pass to make.
+    # build_bootstrap:          whether to enable bootstrap build.
+    #
+    if [ "${SEMAPHORE}" = "true" ]; then
+        if [ -z "${SEMAPHORE_CACHE_DIR}" ]; then
+            export SEMAPHORE_CACHE_DIR="$PWD/gcc-deps"
+        fi;
+        if [ -z "${SEMAPHORE_PROJECT_DIR}" ]; then
+            export SEMAPHORE_PROJECT_DIR="$PWD"
+        fi;
+        project_dir=${SEMAPHORE_PROJECT_DIR}
+        cache_dir=${SEMAPHORE_CACHE_DIR}
+        cache restore $SEMAPHORE_PROJECT_NAME-deps
+        build_host=$($CC -dumpmachine)
+        build_host_canonical=$(/usr/share/misc/config.sub ${build_host})
+        build_target=${build_host}
+        build_target_canonical=${build_host_canonical}
+        make_flags="-j$(nproc)"
+        build_bootstrap="disable"
+    elif [ "${BUILDKITE}" = "true" ]; then
+        project_dir=${PWD}
+        cache_dir=${BUILDKITE_CACHE_DIR}
+        build_host=$($CC -dumpmachine)
+        build_host_canonical=$(/usr/share/misc/config.sub ${build_host})
+        build_target=${BUILDKITE_TARGET}
+        build_target_canonical=$(/usr/share/misc/config.sub ${build_target})
+        make_flags="-j$(nproc) -sw LIBTOOLFLAGS=--silent"
+        build_bootstrap=${BUILDKITE_BOOTSTRAP}
+    elif [ "${AZURE}" = "true" ]; then
+        project_dir=${PWD}
+        cache_dir="${PWD}/gcc-deps"
+        build_host=$($CC -dumpmachine)
+        build_host_canonical=$(/usr/share/misc/config.sub ${build_host})
+        build_target=${build_host}
+        build_target_canonical=${build_host_canonical}
+        make_flags="-j$(nproc)"
+        build_bootstrap="disable"
+    else
+        echo "Unhandled CI environment"
+        exit 1
+    fi
+
+    ## Options determined by target, what steps to skip, or extra flags to add.
+    ## Also, should the testsuite be ran under a simulator?
+    #
+    # build_supports_phobos:    whether to build phobos and run unittests.
+    # build_target_phobos:      where to run the phobos testsuite from.
+    # build_enable_languages:   which languages to build, this affects whether C++
+    #                           or LTO tests are ran in the testsuite.
+    # build_prebuild_script:    script to run after sources have been extracted.
+    # build_configure_flags:    extra configure flags for the target.
+    # build_test_flags:         options to pass to RUNTESTFLAGS.
+    #
+    build_supports_phobos='yes'
+    build_target_phobos=''
+    build_enable_languages='c++,d,lto'
+    build_prebuild_script=''
+    build_configure_flags=''
+    build_test_flags=''
+
+    # Check whether this is a cross or multiarch compiler.
+    if [ "${build_host_canonical}" != "${build_target_canonical}" ]; then
+        multilib_targets=( $(${CC} -print-multi-lib | cut -f2 -d\;) )
+        is_cross_compiler=1
+
+        for multilib in ${multilib_targets[@]}; do
+            build_multiarch=$(${CC} -print-multiarch ${multilib/@/-})
+            build_multiarch_canonical=$(/usr/share/misc/config.sub ${build_multiarch})
+
+            # This is a multiarch compiler, update target to the host compiler.
+            if [ "${build_multiarch_canonical}" = "${build_target_canonical}" ]; then
+                build_target=$build_host
+                build_target_canonical=$build_host_canonical
+                build_target_phobos="${build_target}/$(${CC} ${multilib/@/-} -print-multi-directory)/libphobos"
+                build_test_flags="--target_board=unix{${multilib/@/-}}"
+                build_configure_flags='--enable-multilib --enable-multiarch'
+                is_cross_compiler=0
+                break
+            fi
+        done
+
+        # Building a cross compiler, need to explicitly say where to find native headers.
+        if [ ${is_cross_compiler} -eq 1 ]; then
+            build_configure_flags="--with-native-system-header-dir=/usr/${build_target}/include"
+
+            # Note: setting target board to something other than "generic" only makes
+            # sense if phobos is being built. Without phobos, all runnable tests will
+            # all fail as being 'UNRESOLVED', and so are never ran anyway.
+            case ${build_target_canonical} in
+                arm*-*-*)
+                    build_test_flags='--target_board=buildci-arm-sim'
+                    ;;
+                *)
+                    build_test_flags='--target_board=buildci-generic-sim'
+                    ;;
+            esac
+        fi
+    fi
+
+    if [ "${build_target_phobos}" = "" ]; then
+        build_target_phobos="${build_target}/libphobos"
+    fi
+
+    # Unless requested, don't build with multilib.
+    if [ `expr "${build_configure_flags}" : '.*enable-multilib'` -eq 0 ]; then
+        build_configure_flags="--disable-multilib ${build_configure_flags}"
+    fi
+
+    # If bootstrapping, be sure to turn off slow tree checking.
+    if [ "${build_bootstrap}" = "enable" ]; then
+        build_configure_flags="${build_configure_flags} \
+            --enable-bootstrap --enable-checking=release"
+    else
+        build_configure_flags="${build_configure_flags} \
+            --disable-bootstrap --enable-checking"
+    fi
+
+    # Determine correct flags for configuring a compiler for target.
+    case ${build_target_canonical} in
+      arm-*-*eabihf)
+            build_configure_flags="${build_configure_flags} \
+                --with-arch=armv7-a --with-fpu=vfpv3-d16 --with-float=hard --with-mode=thumb"
+            build_prebuild_script="${cache_dir}/patches/arm-multilib.sh"
+            ;;
+      arm*-*-*eabi)
+            build_configure_flags="${build_configure_flags} \
+                --with-arch=armv5t --with-float=soft"
+            ;;
+      mips-*-*|mipsel-*-*)
+            build_configure_flags="${build_configure_flags} \
+                --with-arch=mips32r2"
+            ;;
+      mips64*-*-*)
+            build_configure_flags="${build_configure_flags} \
+                --with-arch-64=mips64r2 --with-abi=64"
+            ;;
+      powerpc64le-*-*)
+            build_configure_flags="${build_configure_flags} \
+                --with-cpu=power8 --with-long-double-format=ieee"
+            ;;
+      powerpc64-*-*)
+            build_configure_flags="${build_configure_flags} \
+                --with-cpu=power7"
+            ;;
+      x86_64-*-*)
+            ;;
+      *)
+            build_supports_phobos='no'
+            build_enable_languages='c++,d --disable-lto'
+            ;;
+    esac
+}
+
+installdeps() {
+    ## Install build dependencies.
+    # Would save 1 minute if these were preinstalled in some docker image.
+    # But the network speed is nothing to complain about so far...
+    sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    sudo apt-get update -qq
+    sudo apt-get install -qq gcc-${host_package} g++-${host_package} gdc-${host_package} \
+        autogen autoconf automake bison dejagnu flex rsync patch || exit 1
+}
+
+configure() {
+    ## And download GCC prerequisites.
+    # Makes use of local cache to save downloading on every build run.
+    for prereq in ${gcc_prereqs}; do
+        if [ ! -e ${cache_dir}/infrastructure/${prereq} ]; then
+            curl "ftp://gcc.gnu.org/pub/gcc/infrastructure/${prereq}" \
+                --create-dirs -o ${cache_dir}/infrastructure/${prereq} || exit 1
+        fi
+        tar -C ${project_dir} -xf ${cache_dir}/infrastructure/${prereq}
+        ln -s "${project_dir}/${prereq%.tar*}" "${project_dir}/${prereq%-*}"
+    done
+
+    if [ "${SEMAPHORE}" = "true" ]; then
+        cache store $SEMAPHORE_PROJECT_NAME-deps $cache_dir
+    fi
+
+    ## Apply any ad-hoc fixes to the sources.
+    if [ "${build_prebuild_script}" != "" ]; then
+       source ${build_prebuild_script}
+    fi
+
+    ## Create the build directory.
+    # Build typically takes around 10 minutes with -j4, could this be cached across CI runs?
+    mkdir ${project_dir}/build
+    cd ${project_dir}/build
+
+    ## Configure GCC to build a D compiler.
+    ${project_dir}/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --with-sysroot=/ \
+        --enable-languages=${build_enable_languages} --enable-link-mutex \
+        --disable-werror --disable-libgomp --disable-libmudflap \
+        --disable-libquadmath --disable-libitm --disable-libsanitizer \
+        --build=${build_host} --host=${build_host} --target=${build_target} \
+        ${build_configure_flags} --with-bugurl="http://bugzilla.gdcproject.org"
+}
+
+setup() {
+    installdeps
+    environment
+    configure
+}
+
+build() {
+    if [ "${build_bootstrap}" = "enable" ]; then
+        ## Build the entire project to completion.
+        cd ${project_dir}/build
+        make ${make_flags}
+    else
+        ## Build the bare-minimum in order to run tests.
+        cd ${project_dir}/build
+        make ${make_flags} all-gcc || exit 1
+
+        # Note: libstdc++ and libphobos are built separately so that build errors don't mix.
+        if [ "${build_supports_phobos}" = "yes" ]; then
+            make ${make_flags} all-target-libstdc++-v3 || exit 1
+            make ${make_flags} all-target-libphobos || exit 1
+        fi
+    fi
+}
+
+testsuite() {
+    ## Run just the compiler testsuite.
+    cd ${project_dir}/build
+
+    make check-gcc RUNTESTFLAGS="help.exp"
+    make ${make_flags} check-gcc-d RUNTESTFLAGS="${build_test_flags}"
+
+    # For now, be lenient towards any failures, just report on them.
+    summary
+}
+
+unittests() {
+    ## Run just the library unittests.
+    if [ "${build_supports_phobos}" = "yes" ]; then
+        cd ${project_dir}/build
+        if ! make ${make_flags} -C ${build_target_phobos} check RUNTESTFLAGS="${build_test_flags}"; then
+            echo "== Unittest has failures =="
+            exit 1
+        fi
+    fi
+}
+
+summary() {
+    ## Processes *.{sum,log} files, producing a summary of all testsuite runs.
+    cd ${project_dir}/build
+    files=`find . -name \*.sum -print | sort`
+    anyfile=false
+
+    for file in $files; do
+        if [ -f $file ]; then
+            anyfile=true
+        fi
+    done
+
+    # Based on GCC testsuite summary scripts.
+    if [ "${anyfile}" = "true" ]; then
+        # We use cat instead of listing the files as arguments to AWK because
+        # GNU awk 3.0.0 would break if any of the filenames contained `=' and
+        # was preceded by an invalid variable name.
+        ( echo @TOPLEVEL_CONFIGURE_ARGUMENTS@ | ./config.status --file=-; cat $files ) |
+        awk '
+        BEGIN {
+            lang=""; configflags = "";
+            version="gcc";
+        }
+        NR == 1 {
+            configflags = $0 " ";
+            srcdir = configflags;
+            sub(/\/configure\047? .*/, "", srcdir);
+            sub(/^\047/, "", srcdir);
+            if ( system("test -f " srcdir "/LAST_UPDATED") == 0 ) {
+                printf "LAST_UPDATED: ";
+                system("tail -1 " srcdir "/LAST_UPDATED");
+                print "";
+            }
+
+            sub(/^[^ ]*\/configure\047? */, " ", configflags);
+            sub(/,;t t $/, " ", configflags);
+            sub(/ --with-gcc-version-trigger=[^ ]* /, " ", configflags);
+            sub(/ --norecursion /, " ", configflags);
+            sub(/ $/, "", configflags);
+            sub(/^ *$/, " none", configflags);
+            configflags = "configure flags:" configflags;
+        }
+        /^Running target / { print; }
+        /^Target / { if (host != "") next; else host = $3; }
+        /^Host / && host ~ /^unix\{.*\}$/ { host = $3 " " substr(host, 5); }
+        /^Native / { if (host != "") next; else host = $4; }
+        /^[     ]*=== [^        ]+ tests ===/ {
+            if (lang == "") lang = " "$2" "; else lang = " ";
+        }
+        $2 == "version" {
+            save = $0; $1 = ""; $2 = ""; version = $0; gsub(/^ */, "", version); gsub(/\r$/, "", version); $0 = save;
+        }
+        /\===.*Summary/ || /tests ===/ { print ""; print; blanks=1; }
+        /^(Target|Host|Native)/ { print; }
+        /^(XPASS|FAIL|UNRESOLVED|WARNING|ERROR|# of )/ { sub ("\r", ""); print; }
+        /^using:/ { print ""; print; print ""; }
+        /^$/ && blanks>0 { print; --blanks; }
+        END {
+            if (lang != "") {
+                print "";
+                print "Compiler version: " prefix version lang;
+                print "Platform: " host;
+                print configflags;
+            }
+        }
+        { next; }
+        ' | sed "s/\([\`\$\\\\]\)/\\\\\\1/g"
+    fi
+}
+
+## Run a single build task or all at once.
+if [ "$1" != "" ]; then
+    # Skip calling environment if running setup, as dependencies might not be installed yet.
+    if [ "$1" != "setup" ]; then
+        environment
+    fi
+    $1
+else
+    setup
+    build
+    unittests
+fi

--- a/gcc/testsuite/lib/gdc.exp
+++ b/gcc/testsuite/lib/gdc.exp
@@ -154,6 +154,9 @@ proc gdc_link_flags { paths } {
 	    append flags "-L${gccpath}/libstdc++-v3/src/.libs "
 	    append ld_library_path ":${gccpath}/libstdc++-v3/src/.libs"
 	}
+	if [file isdirectory "${gccpath}/libgcc/shlib"] {
+	    append ld_library_path ":${gccpath}/libgcc/shlib"
+	}
 	append ld_library_path [gcc-set-multilib-library-path $GDC_UNDER_TEST]
     } else {
 	global tool_root_dir

--- a/libphobos/testsuite/lib/libphobos.exp
+++ b/libphobos/testsuite/lib/libphobos.exp
@@ -149,6 +149,11 @@ proc libphobos_init { args } {
 	append ld_library_path ":${blddir}/src/.libs"
     }
 
+    if [file isdirectory "${blddir}/../libgcc/shlib"] {
+        append ld_library_path ":${blddir}/../libgcc/shlib"
+    }
+
+
     set_ld_library_path_env_vars
 
     libphobos_maybe_build_wrapper "${objdir}/testglue.o"


### PR DESCRIPTION
When we do any configure tests against libgcc, these are done against the newly built libgcc. So when testing, we should also use that libgcc instead of the system one.

```
gcc/testsuite/ChangeLog:

2019-03-02  Johannes Pfau  <johannespfau@gmail.com>

	* lib/gdc.exp: Add newly built libgcc to library paths.

libphobos/ChangeLog:

2019-03-02  Johannes Pfau  <johannespfau@gmail.com>

	* testsuite/lib/libphobos.exp: Add newly built libgcc to library paths.

```