### PR TITLE
DMD-CXX backport

### DIFF
--- a/configure
+++ b/configure
@@ -3395,7 +3395,7 @@ case ,${enable_languages}, in
     ;;
   *)
     case "${target}" in
-      *-*-darwin* | *-*-cygwin* | *-*-mingw*)
+      *-*-darwin* | *-*-cygwin*)
 	unsupported_languages="$unsupported_languages d"
 	;;
     esac

--- a/configure.ac
+++ b/configure.ac
@@ -680,7 +680,7 @@ case ,${enable_languages}, in
     ;;
   *)
     case "${target}" in
-      *-*-darwin* | *-*-cygwin* | *-*-mingw*)
+      *-*-darwin* | *-*-cygwin*)
 	unsupported_languages="$unsupported_languages d"
 	;;
     esac

--- a/gcc/d/d-system.h
+++ b/gcc/d/d-system.h
@@ -55,4 +55,10 @@
 #undef tolower
 #define tolower(c) TOLOWER(c)
 
+/* We do not include direct.h as it conflicts with system.h.  */
+#ifdef _WIN32
+#undef _mkdir
+#define _mkdir(p) mkdir(p, 0)
+#endif
+
 #endif  /* GCC_D_SYSTEM_H  */


### PR DESCRIPTION
@ibuclaw This backports latest dmd-cxx. Is there a PR for the `dmodule.c` change?

```
gcc/d/ChangeLog:

2019-03-23  Johannes Pfau  <johannespfau@gmail.com>
	PR d/87799
	* d-system.h (_mkdir): Define to mkdir for MinGW hosts.
	* dmd/root/filename.c: Merge related dmd-cxx fixes.
```